### PR TITLE
Report gateware version and memory status

### DIFF
--- a/Source/DeviceThread.h
+++ b/Source/DeviceThread.h
@@ -338,6 +338,9 @@ namespace ONIRhythmNode
 		/** Initialize the board*/
 		void initializeBoard();
 
+		/**Check board memory status */
+		bool checkBoardMem() const;
+
 		/** Update register settings*/
 		void updateRegisters();
 

--- a/Source/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/rhythm-api/rhd2000ONIboard.cpp
@@ -957,3 +957,21 @@ void Rhd2000ONIBoard::setDacManual(int value)
         oni_destroy_frame(frame);
     }
 }
+
+bool Rhd2000ONIBoard::getFirmwareVersion(int* major, int* minor) const
+{
+    if (!ctx) return false;
+    oni_reg_val_t val;
+    if (oni_read_reg(ctx, 254, 2, &val) != ONI_ESUCCESS) return false;
+    *minor = val & 0xFF;
+    *major = (val >> 8) & 0xFF;
+    return true;
+}
+
+Rhd2000ONIBoard::BoardMemState Rhd2000ONIBoard::getBoardMemState() const
+{
+    if (!ctx) return BOARDMEM_INVALID;
+    oni_reg_val_t val;
+    if (oni_read_reg(ctx, 254, 0x1000, &val) != ONI_ESUCCESS) return BOARDMEM_INVALID;
+    return static_cast<BoardMemState>(val & 0x03);
+}

--- a/Source/rhythm-api/rhd2000ONIboard.h
+++ b/Source/rhythm-api/rhd2000ONIboard.h
@@ -131,6 +131,18 @@ public:
     void setDacManual(int value);
      void setDacGain(int gain);
 
+    bool getFirmwareVersion(int* major, int* minor) const;
+
+    enum BoardMemState
+    {
+        BOARDMEM_INIT = 0,
+        BOARDMEM_OK = 1,
+        BOARDMEM_INVALID = 2, //this should not happen
+        BOARDMEM_ERR = 3
+    };
+
+    BoardMemState getBoardMemState() const;
+
 private:
     const oni_size_t usbReadBlockSize = 24 * 1024;
 


### PR DESCRIPTION
v02 which reports in the console the gateware version on the acquisition board, useful for debug.
Also checks the memory initialization status, informing through the console if it is initializing, which can take up to 20 seconds, to avoid the impression of a crash.