### PR TITLE
Support for newer board firmware

### DIFF
--- a/Source/DeviceThread.h
+++ b/Source/DeviceThread.h
@@ -370,6 +370,8 @@ namespace ONIRhythmNode
 		StringArray channelNames;
 		CriticalSection oniLock;
 
+		int regOffset;
+
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DeviceThread);
 	};
 


### PR DESCRIPTION
This adds support for a new firmware that will be integrates in boards leaving OEPS soon, fixing issues with some 64-channel headstages, while maintaining compatibility with older firmwares by autodetecting the version.

@jsiegle could this be published soon, so when the new boards arrive to their users, they can use them?