### PR TITLE
Workaround for impedance measurement bug

### DIFF
--- a/Source/DeviceThread.cpp
+++ b/Source/DeviceThread.cpp
@@ -2136,9 +2136,13 @@ short DeviceThread::getAdcRange(int channel) const
 void DeviceThread::runImpedanceTest()
 {
     if (!checkBoardMem()) return;
-    impedanceThread->stopThreadSafely();
+    //impedanceThread->stopThreadSafely();
+
+    setSampleRate(Rhd2000ONIBoard::SampleRate30000Hz, true, false); // set to 30 kHz temporarily
 
     impedanceThread->runThread();
+
+    setSampleRate(settings.savedSampleRateIndex, false, true); // set to 30 kHz temporarily
 
 }
 

--- a/Source/DeviceThread.cpp
+++ b/Source/DeviceThread.cpp
@@ -2136,7 +2136,6 @@ short DeviceThread::getAdcRange(int channel) const
 void DeviceThread::runImpedanceTest()
 {
     if (!checkBoardMem()) return;
-    //impedanceThread->stopThreadSafely();
 
     setSampleRate(Rhd2000ONIBoard::SampleRate30000Hz, true, false); // set to 30 kHz temporarily
 

--- a/Source/ImpedanceMeter.cpp
+++ b/Source/ImpedanceMeter.cpp
@@ -359,7 +359,7 @@ void ImpedanceMeter::runImpedanceMeasurement(Impedances& impedances)
     int numPeriods = (0.020 * actualImpedanceFreq); // Test each channel for at least 20 msec...
     if (numPeriods < 5) numPeriods = 5; // ...but always measure across no fewer than 5 complete periods
     double period = board->settings.boardSampleRate / actualImpedanceFreq;
-    int numBlocks = ceil((numPeriods + 2) * period / (float(SAMPLES_PER_DATA_BLOCK(board->evalBoard->isUSB3()))));  // + 2 periods to give time to settle initially
+    int numBlocks = ceil((numPeriods + 2) * period / float(SAMPLES_PER_DATA_BLOCK(board->evalBoard->isUSB3())));  // + 2 periods to give time to settle initially
     if (numBlocks < 2) numBlocks = 2;   // need first block for command to switch channels to take effect.
 
     CHECK_EXIT;

--- a/Source/ImpedanceMeter.cpp
+++ b/Source/ImpedanceMeter.cpp
@@ -360,7 +360,9 @@ void ImpedanceMeter::runImpedanceMeasurement(Impedances& impedances)
     if (numPeriods < 5) numPeriods = 5; // ...but always measure across no fewer than 5 complete periods
     double period = board->settings.boardSampleRate / actualImpedanceFreq;
     int numBlocks = ceil((numPeriods + 2) * period / float(SAMPLES_PER_DATA_BLOCK(board->evalBoard->isUSB3())));  // + 2 periods to give time to settle initially
+    LOGD("ImpedanceMeter: Initial numBlocks = ", numBlocks);
     if (numBlocks < 2) numBlocks = 2;   // need first block for command to switch channels to take effect.
+    LOGD("ImpedanceMeter: Padded numBlocks = ", numBlocks);
 
     CHECK_EXIT;
     board->settings.dsp.cutoffFreq = board->chipRegisters.setDspCutoffFreq(board->settings.dsp.cutoffFreq);

--- a/Source/ImpedanceMeter.cpp
+++ b/Source/ImpedanceMeter.cpp
@@ -359,7 +359,7 @@ void ImpedanceMeter::runImpedanceMeasurement(Impedances& impedances)
     int numPeriods = (0.020 * actualImpedanceFreq); // Test each channel for at least 20 msec...
     if (numPeriods < 5) numPeriods = 5; // ...but always measure across no fewer than 5 complete periods
     double period = board->settings.boardSampleRate / actualImpedanceFreq;
-    int numBlocks = ceil((numPeriods + 2.0) * period / 60.0);  // + 2 periods to give time to settle initially
+    int numBlocks = ceil((numPeriods + 2) * period / (float(SAMPLES_PER_DATA_BLOCK(board->evalBoard->isUSB3()))));  // + 2 periods to give time to settle initially
     if (numBlocks < 2) numBlocks = 2;   // need first block for command to switch channels to take effect.
 
     CHECK_EXIT;


### PR DESCRIPTION
Addressing the [issue](https://github.com/open-ephys/plugin-GUI/issues/602#issuecomment-1989143548) regarding impedance test bugs with the new board.

After some debugging, it seemed that the issue with running impedance measurements at sampling rates other than 30 kS/s was failing due to the estimate of how many blocks to write/read. The original line to compute `numBlocks` was 

`int numBlocks = ceil((numPeriods + 2) * period / 60.0);`

`numBlocks` is used to determine the `maxTimeStep` and the number of frames to read via setting the number of `Rhd2000DataBlocks`. Feels like the magic number, `60.0` is a potential culprit... doesn't really make sense... the denominator here should probably be `float(SAMPLES_PER_DATA_BLOCK(board->evalBoard->isUSB3())`.

I tried to sus out what the correct calculation should be by digging through other parts of the code and the chip datasheets - but after much obsessive sleuthing and several changes that made things better but still fail, I decided I should just pass on what I've found to someone more familiar with how the chip works. 

As a workaround, I noticed that in `DeviceThread::scanPorts`, the sampling rate is temporarily set to 30 kS/s. For now, I've used this approach for impedance measurements as well and it seems to work. I have a component with a known of impedance of 4.5 kOhm which I used to verify this change.

Some potential clues on the core issue:
- In the original code, the issue was an infinite loop that occurred when reading frames in `board->evalBoard->readDataBlocks(numBlocks, dataQueue);`. The infinite loop is a result of `(*frame)->dev_idx == DEVICE_RHYTHM` being false for the frames that are read.
- When you hard code `numBlocks = 11` which is the value computed for 30 kS/s, there's no more infinite loop for all sampling rates but the calculation only correct for 30 ks/S. Not sure if there's anything to this, but it makes me think that somewhere else in the code, there's another value that implicitly depends on the sampling rate being 30 kS/s - like `60.0`. Or maybe some chip setting for outputs isn't set or isn't compatible with subsampled rates?
- There's potentially some interplay with setting the `maxStepSize`. 
- I changed `60.0` to `float(SAMPLES_PER_DATA_BLOCK(board->evalBoard->isUSB3())`, and the impedance test still works for 30 kS/s even though `numBlocks = 3` now. However, it still fails for other rates. Nonetheless, I left this change in since I think it's correct.

In any case, the current workaround seems fine, and it doesn't add much time to switch sampling rates.
